### PR TITLE
feat: Support kitty and win32-input-mode protocols (fixes #30)

### DIFF
--- a/source/dcell/ttyscreen.d
+++ b/source/dcell/ttyscreen.d
@@ -98,9 +98,8 @@ class TtyScreen : Screen
         // - xterm modifyOtherKeys (uses CSI 27 ~ )
         // - kitty csi-u (uses CSI u)
         // - win32-input-mode (uses CSI _)
-        string enableCsiU = "\x1b[>4;2m" ~ "\x1b[>1u" ~ "\x1b[9001h";
-        string disableCsiU = "\x1b[9001l" ~ "\x1b[<u" ~ "\x1b[>4;0m";
-
+        string enableCsiU = "\x1b[>4;2m" ~ "\x1b[>1u" ~ "\x1b[?9001h";
+        string disableCsiU = "\x1b[?9001l" ~ "\x1b[<u" ~ "\x1b[>4;0m";
         // number of colors - again this can be overridden.
         // Typical values are 0 (monochrome), 8, 16, 256, and 1<<24.
         // There are some oddballs like xterm-88color.  The first


### PR DESCRIPTION
This adds support for advanced key reporting modes, borrowed from tcell.  This also includes the X term modifyOtherKeys protocol.

Note that win32-input-mode is not tested yet as we don't fully support Windows (no termio implementation for it yet), but that will change soon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced keyboard protocol support with automatic detection and configuration for Windows and WezTerm terminals.
  * Better compatibility with modern terminal emulator features and improved keyboard input handling.

* **Bug Fixes**
  * Ensure terminal mode toggles are reliably emitted on screen start and stop to prevent stale input state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->