### PR TITLE
fix: address possible overflow with duration max

### DIFF
--- a/source/dcell/termio.d
+++ b/source/dcell/termio.d
@@ -276,7 +276,7 @@ version (Posix)
                 FD_SET(fd, &readFds);
                 FD_SET(sigRfd, &readFds);
 
-                if (dur.isNegative)
+                if (dur.isNegative || dur == Duration.max)
                 {
                     tvp = null;
                 }
@@ -337,7 +337,7 @@ version (Posix)
                 pfd[1].revents = 0;
 
                 int dly;
-                if (dur.isNegative || dur == dur.max)
+                if (dur.isNegative || dur == Duration.max)
                 {
                     dly = -1;
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timeout handling so "maximum" duration values are treated as indefinite waits, ensuring consistent behavior across different read/poll paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->