### PR TITLE
feat: use alternate screen when possible (and add override) (fixes #18)

### DIFF
--- a/source/dcell/screen.d
+++ b/source/dcell/screen.d
@@ -148,6 +148,15 @@ interface Screen
     }
 
     /**
+     * Enable or disable the alternate screen. This must be called
+     * before start().  Note that this is best effort -- not every
+     * terminal actually supports this.  This is on by default.
+     * It can be disabled by setting DCELL_ALTSCREEN=disable in the
+     * environment.
+     */
+    void enableAlternateScreen(bool on);
+
+    /**
      * If the terminal supports color, this returns the
      * the number of colors.
      *

--- a/source/dcell/ttyscreen.d
+++ b/source/dcell/ttyscreen.d
@@ -211,6 +211,15 @@ class TtyScreen : Screen
             vt.numColors = 0;
         }
 
+        if (environment.get("DCELL_ALTSCREEN") == "disable")
+        {
+            altScrEn = false;
+        }
+        else
+        {
+            altScrEn = true;
+        }
+
         version (Windows)
         {
             // If we don't have a $TERM (e.g. Windows Terminal), or we are dealing with WezTerm
@@ -251,6 +260,11 @@ class TtyScreen : Screen
         puts(vt.hideCursor);
         puts(vt.disableAutoMargin);
         puts(vt.enableCsiU);
+        if (altScrEn)
+        {
+            puts(vt.enterCA);
+        }
+        puts(vt.saveTitle);
         puts(vt.enterKeypad);
         puts(vt.enableAltChars);
         puts(vt.clear);
@@ -272,7 +286,11 @@ class TtyScreen : Screen
         puts(vt.cursorReset);
         puts(vt.showCursor);
         puts(vt.cursorReset);
-        puts(vt.clear);
+        if (altScrEn)
+        {
+            puts(vt.clear);
+            puts(vt.exitCA);
+        }
         puts(vt.exitKeypad);
         puts(vt.disablePaste);
         puts(vt.disableMouse);
@@ -406,6 +424,15 @@ class TtyScreen : Screen
         flush();
     }
 
+    void enableAlternateScreen(bool enabled)
+    {
+        altScrEn = enabled;
+        if (environment.get("DCELL_ALTSCREEN") == "disable")
+        {
+            altScrEn = false;
+        }
+    }
+
     Event waitEvent(Duration dur = msecs(100))
     {
         // naive polling loop for now.
@@ -480,6 +507,7 @@ private:
     Cursor cursorShape;
     MouseEnable mouseEn; // saved state for suspend/resume
     bool pasteEn; // saved state for suspend/resume
+    bool altScrEn; // alternate screen is enabled (default on)
     Tty ti;
     OutBuffer ob;
     bool started;


### PR DESCRIPTION
This uses the altscreen, but gives an environment variable to override, as well as in-application support for this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added alternate screen mode support for enhanced terminal compatibility. Users can now control whether the application uses an alternate screen buffer through the `enableAlternateScreen()` API method or by setting the `DCELL_ALTSCREEN` environment variable. Alternate screen mode is enabled by default but can be disabled by setting `DCELL_ALTSCREEN=disable`.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->