### PR TITLE
chore!: Remove the focus enable API.

### DIFF
--- a/demos/mouse/source/mouse.d
+++ b/demos/mouse/source/mouse.d
@@ -108,7 +108,6 @@ void main()
     s.showCursor(Cursor.hidden);
     s.enableMouse(MouseEnable.all);
     s.enablePaste(true);
-    s.enableFocus(true);
     Style white;
     white.fg = Color.midnightBlue;
     white.bg = Color.lightCoral;

--- a/source/dcell/screen.d
+++ b/source/dcell/screen.d
@@ -110,15 +110,6 @@ interface Screen
     void enablePaste(bool b);
 
     /**
-     * Enable focus reporting. This will cause focus events to be sent
-     * when the window focus changes.
-     *
-     * Params:
-     *   b = true to enable focus reporting, false to disable
-     */
-    void enableFocus(bool b);
-
-    /**
      * Enable mouse mode.  This can cause terminals/emulators
      * to behave differently -- for example affecting the ability
      * to scroll or use copy/paste.

--- a/source/dcell/ttyscreen.d
+++ b/source/dcell/ttyscreen.d
@@ -266,6 +266,7 @@ class TtyScreen : Screen
         }
         puts(vt.saveTitle);
         puts(vt.enterKeypad);
+        puts(vt.enableFocus);
         puts(vt.enableAltChars);
         puts(vt.clear);
 
@@ -416,12 +417,6 @@ class TtyScreen : Screen
         // information.
         mouseEn = en; // save this so we can restore after a suspend
         sendMouseEnable(en);
-    }
-
-    void enableFocus(bool enabled)
-    {
-        puts(enabled ? Vt.enableFocus : Vt.disableFocus);
-        flush();
     }
 
     void enableAlternateScreen(bool enabled)


### PR DESCRIPTION
There is no reason for focus events to not always be enabled. This is unlike mouse or paste events, where the application might reasonably want to have different behaviors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Focus handling is now automatically enabled during startup. The ability to manually control focus enablement through a public method has been removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->