### PR TITLE
Now multi-line bracketed paste preserves newlines

### DIFF
--- a/source/dcell/parser.d
+++ b/source/dcell/parser.d
@@ -1319,6 +1319,24 @@ private:
         assert(ev[0].type == EventType.paste);
         assert(ev[0].paste.content == "A\nB");
 
+        // multi-line paste (CRLF newlines) - normalize and de-duplicate
+        assert(p.parse(['\x1b', '[', '2', '0', '0', '~']));
+        assert(p.parse("A\r\nB"));
+        assert(p.parse(['\x1b', '[', '2', '0', '1', '~']));
+        ev = p.events();
+        assert(ev.length == 1);
+        assert(ev[0].type == EventType.paste);
+        assert(ev[0].paste.content == "A\nB");
+
+        // LF newlines outside paste should keep legacy Ctrl-J behavior
+        assert(p.parse("\n"));
+        ev = p.events();
+        assert(ev.length == 1);
+        assert(ev[0].type == EventType.key);
+        assert(ev[0].key.key == Key.graph);
+        assert(ev[0].key.ch == 'j');
+        assert(ev[0].key.mod == Modifiers.ctrl);
+
         // mouse events
         assert(p.parse(['\x1b', '[', '<', '3', ';', '2', ';', '3', 'M']));
         ev = p.events();


### PR DESCRIPTION
Pasting multi-line text is broken. The postKey function, when in pasting mode, only appends Key.graph events to the paste buffer. Since newlines are typically parsed as Key.enter, they are silently discarded, resulting in all pasted text being joined into a single line. This PR fixes this issue I believe. Includes some unittests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of bracketed paste so multi-line pastes preserve intended newlines and avoid duplicate blank lines; line endings (CR, LF, CR/LF) are normalized.
  * Paste buffer now reliably flushes pasted content at paste end for consistent input behavior.

* **Tests**
  * Added tests covering LF- and CR-based multi-line paste scenarios to ensure consistent behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->