### PR TITLE
Fix: Bounds checking for repeat count in `handleWinKey`

### DIFF
--- a/source/dcell/parser.d
+++ b/source/dcell/parser.d
@@ -1001,6 +1001,21 @@ private:
         evs ~= newMouseEvent(x, y, button, mod);
     }
 
+    /***
+     * Handles Win32 input mode key sequences (CSI ... _).
+     *
+     * Parses a Win32 console input key event encoded as a CSI sequence with
+     * six semicolon-separated parameters, and translates it into one or more
+     * key events appended to `evs`.
+     *
+     * Params:
+     *   p0 = wVirtualKeyCode (default 0)
+     *   p1 = wVirtualScanCode (default 0)
+     *   p2 = UnicodeChar as a decimal value (default 0)
+     *   p3 = bKeyDown — 1 for key-down, 0 for key-up (default 0)
+     *   p4 = dwControlKeyState — modifier flags (default 0)
+     *   p5 = wRepeatCount — clamped to [1, 1024] to prevent CPU hang (default 1)
+     */
     void handleWinKey(int p0, int p1, int p2, int p3, int p4, int p5) @safe
     {
         // win32-input-mode

--- a/source/dcell/parser.d
+++ b/source/dcell/parser.d
@@ -12,7 +12,7 @@
 module dcell.parser;
 
 import core.time;
-import std.algorithm : max;
+import std.algorithm : max, min;
 import std.ascii;
 import std.base64;
 import std.conv : to;
@@ -1046,7 +1046,7 @@ private:
         auto key = Key.graph;
         auto chr = p2;
         auto mod = Modifiers.none;
-        auto rpt = max(1, p5);
+        auto rpt = min(max(1, p5), 1024);
 
         if (p0 in winKeys)
         {


### PR DESCRIPTION
In `source/dcell/parser.d`, the `p5` parameter (repeat count) in `handleWinKey` was used without an upper bound, allowing a malicious terminal to send a very large value and cause CPU hang.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented excessively large keyboard repeat counts by clamping repetitions to a safe range (1–1024), improving stability for Windows input.
* **Documentation**
  * Added explanatory notes on Win32 input-mode key sequence handling to clarify behavior for users and maintainers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->